### PR TITLE
Support more GitHub events

### DIFF
--- a/src/bot/emoji.rs
+++ b/src/bot/emoji.rs
@@ -3,3 +3,5 @@ pub(crate) const GRADUATION_CAP: char = '\u{1F393}';
 pub(crate) const OUTBOX_TRAY: char = '\u{1F4E4}';
 pub(crate) const SPEECH_BALLOON: char = '\u{1F4AC}';
 pub(crate) const WRENCH: char = '\u{1F527}';
+pub(crate) const PING_PONG: char = '\u{1F3D3}';
+pub(crate) const PACKAGE: char = '\u{1F4E6}';

--- a/src/bot/emoji.rs
+++ b/src/bot/emoji.rs
@@ -5,3 +5,4 @@ pub(crate) const SPEECH_BALLOON: char = '\u{1F4AC}';
 pub(crate) const WRENCH: char = '\u{1F527}';
 pub(crate) const PING_PONG: char = '\u{1F3D3}';
 pub(crate) const PACKAGE: char = '\u{1F4E6}';
+pub(crate) const PEOPLE: char = '\u{1F9D1}';

--- a/src/bot/emoji.rs
+++ b/src/bot/emoji.rs
@@ -1,8 +1,8 @@
 pub(crate) const FIRE: char = '\u{1F525}';
 pub(crate) const GRADUATION_CAP: char = '\u{1F393}';
 pub(crate) const OUTBOX_TRAY: char = '\u{1F4E4}';
-pub(crate) const SPEECH_BALLOON: char = '\u{1F4AC}';
-pub(crate) const WRENCH: char = '\u{1F527}';
-pub(crate) const PING_PONG: char = '\u{1F3D3}';
 pub(crate) const PACKAGE: char = '\u{1F4E6}';
 pub(crate) const PEOPLE: char = '\u{1F9D1}';
+pub(crate) const PING_PONG: char = '\u{1F3D3}';
+pub(crate) const SPEECH_BALLOON: char = '\u{1F4AC}';
+pub(crate) const WRENCH: char = '\u{1F527}';

--- a/src/bot/github.rs
+++ b/src/bot/github.rs
@@ -231,29 +231,21 @@ fn handle_membership(event: crate::webhooks::github::MembershipEvent) -> Option<
         return None;
     }
 
-    match action.as_str() {
-        "added" => {
-            write!(
-                &mut message,
-                " {} added {} to the team",
-                event.sender.login, event.member.login,
-            )
-            .unwrap();
-        }
-        "removed" => {
-            write!(
-                &mut message,
-                " {} removed {} from the team",
-                event.sender.login, event.member.login,
-            )
-            .unwrap();
-        }
-
+    let preposition = match action.as_str() {
+        "added" => "to",
+        "removed" => "from",
         _ => {
             error!("invalid or unsupported membership action: {}", action);
             return None;
         }
     };
+
+    write!(
+        &mut message,
+        " {} {} {} {} the team",
+        event.sender.login, action, event.member.login, preposition
+    )
+    .unwrap();
 
     Some(Response {
         message,

--- a/src/bot/github.rs
+++ b/src/bot/github.rs
@@ -22,6 +22,7 @@ pub fn handle_github_event(event: GitHubEvent) -> anyhow::Result<Option<Response
     let response = match event {
         GitHubEvent::Ping(event) => handle_ping(event),
         GitHubEvent::Create(event) => handle_create(event),
+        GitHubEvent::Fork(event) => handle_fork(event),
         GitHubEvent::Issues(event) => handle_issues(event),
         GitHubEvent::IssueComment(event) => handle_issue_comment(event),
         GitHubEvent::Organization(event) => handle_organization(event),
@@ -83,6 +84,19 @@ fn handle_create(event: CreateEvent) -> Option<Response> {
             message.main_link(&event.r#ref, &ref_url)
         }
     };
+
+    Some(Response {
+        message,
+        repo: Some(event.repository.full_name),
+    })
+}
+
+fn handle_fork(event: crate::webhooks::github::ForkEvent) -> Option<Response> {
+    let mut message = MessageBuilder::new();
+
+    message.tag(&event.repository.name, Some(emoji::PACKAGE));
+    write!(&mut message, " {} forked into ", event.sender.login).unwrap();
+    message.main_link(&event.forkee.full_name, &event.forkee.html_url);
 
     Some(Response {
         message,

--- a/src/bot/message_builder.rs
+++ b/src/bot/message_builder.rs
@@ -9,6 +9,7 @@ enum Style {
     Bold,
     Code,
     Span,
+    Italic,
 }
 
 impl Style {
@@ -17,6 +18,7 @@ impl Style {
             Self::Bold => "</b>",
             Self::Code => "</code>",
             Self::Span => "</span>",
+            Self::Italic => "</i>",
         }
     }
 }
@@ -56,6 +58,11 @@ impl MessageBuilder {
     pub fn color(&mut self, color: &str) {
         write!(self.html, r#"<span style="color: {}">"#, color).unwrap();
         self.style_stack.push(Style::Span);
+    }
+
+    pub fn italic(&mut self) {
+        self.html.push_str("<i>");
+        self.style_stack.push(Style::Italic);
     }
 
     pub fn tag(&mut self, tag: &str, emoji: Option<char>) {

--- a/src/webhooks/github/events.rs
+++ b/src/webhooks/github/events.rs
@@ -6,6 +6,7 @@ use url::Url;
 use crate::bot::utils::shorten_content;
 
 mod create;
+mod fork;
 mod issue_comment;
 mod issues;
 mod organization;
@@ -18,6 +19,7 @@ mod repository;
 mod types;
 
 pub use create::*;
+pub use fork::*;
 pub use issue_comment::*;
 pub use issues::*;
 pub use organization::*;
@@ -33,6 +35,7 @@ pub use types::*;
 pub enum GitHubEvent {
     Ping(PingEvent),
     Create(CreateEvent),
+    Fork(ForkEvent),
     IssueComment(IssueCommentEvent),
     Issues(IssuesEvent),
     Organization(OrganizationEvent),

--- a/src/webhooks/github/events.rs
+++ b/src/webhooks/github/events.rs
@@ -10,6 +10,7 @@ mod create;
 mod fork;
 mod issue_comment;
 mod issues;
+mod membership;
 mod organization;
 mod ping;
 mod pull_request;
@@ -24,6 +25,7 @@ pub use create::*;
 pub use fork::*;
 pub use issue_comment::*;
 pub use issues::*;
+pub use membership::*;
 pub use organization::*;
 pub use ping::*;
 pub use pull_request::*;
@@ -35,13 +37,14 @@ pub use types::*;
 
 #[derive(Debug)]
 pub enum GitHubEvent {
-    Ping(PingEvent),
     CommitComment(CommitCommentEvent),
     Create(CreateEvent),
     Fork(ForkEvent),
     IssueComment(IssueCommentEvent),
     Issues(IssuesEvent),
+    Membership(MembershipEvent),
     Organization(OrganizationEvent),
+    Ping(PingEvent),
     PullRequest(PullRequestEvent),
     PullRequestReview(PullRequestReviewEvent),
     PullRequestReviewComment(PullRequestReviewCommentEvent),
@@ -154,5 +157,15 @@ pub struct PrRef {
 
 #[derive(Debug, Deserialize)]
 pub struct PullRequestLinks {
+    pub html_url: Url,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Team {
+    pub name: String,
+    pub id: u64,
+    pub description: String,
+    pub privacy: String,
+    pub permission: String,
     pub html_url: Url,
 }

--- a/src/webhooks/github/events.rs
+++ b/src/webhooks/github/events.rs
@@ -5,6 +5,7 @@ use url::Url;
 
 use crate::bot::utils::shorten_content;
 
+mod commit_comment;
 mod create;
 mod fork;
 mod issue_comment;
@@ -18,6 +19,7 @@ mod push;
 mod repository;
 mod types;
 
+pub use commit_comment::*;
 pub use create::*;
 pub use fork::*;
 pub use issue_comment::*;
@@ -34,6 +36,7 @@ pub use types::*;
 #[derive(Debug)]
 pub enum GitHubEvent {
     Ping(PingEvent),
+    CommitComment(CommitCommentEvent),
     Create(CreateEvent),
     Fork(ForkEvent),
     IssueComment(IssueCommentEvent),
@@ -101,6 +104,7 @@ pub struct Milestone {
 pub struct Comment {
     pub html_url: Url,
     pub body: String,
+    pub commit_id: Option<String>,
     pub pull_request_review_id: Option<u64>,
     pub path: Option<String>,
     pub position: Option<u64>,

--- a/src/webhooks/github/events.rs
+++ b/src/webhooks/github/events.rs
@@ -8,23 +8,28 @@ use crate::bot::utils::shorten_content;
 mod create;
 mod issue_comment;
 mod issues;
+mod ping;
 mod pull_request;
 mod pull_request_review;
 mod pull_request_review_comment;
 mod push;
+mod repository;
 mod types;
 
 pub use create::*;
 pub use issue_comment::*;
 pub use issues::*;
+pub use ping::*;
 pub use pull_request::*;
 pub use pull_request_review::*;
 pub use pull_request_review_comment::*;
 pub use push::*;
+pub use repository::*;
 pub use types::*;
 
 #[derive(Debug)]
 pub enum GitHubEvent {
+    Ping(PingEvent),
     Create(CreateEvent),
     IssueComment(IssueCommentEvent),
     Issues(IssuesEvent),
@@ -32,6 +37,7 @@ pub enum GitHubEvent {
     PullRequestReview(PullRequestReviewEvent),
     PullRequestReviewComment(PullRequestReviewCommentEvent),
     Push(PushEvent),
+    Repository(RepositoryEvent),
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/webhooks/github/events.rs
+++ b/src/webhooks/github/events.rs
@@ -8,6 +8,7 @@ use crate::bot::utils::shorten_content;
 mod create;
 mod issue_comment;
 mod issues;
+mod organization;
 mod ping;
 mod pull_request;
 mod pull_request_review;
@@ -19,6 +20,7 @@ mod types;
 pub use create::*;
 pub use issue_comment::*;
 pub use issues::*;
+pub use organization::*;
 pub use ping::*;
 pub use pull_request::*;
 pub use pull_request_review::*;
@@ -33,6 +35,7 @@ pub enum GitHubEvent {
     Create(CreateEvent),
     IssueComment(IssueCommentEvent),
     Issues(IssuesEvent),
+    Organization(OrganizationEvent),
     PullRequest(PullRequestEvent),
     PullRequestReview(PullRequestReviewEvent),
     PullRequestReviewComment(PullRequestReviewCommentEvent),

--- a/src/webhooks/github/events.rs
+++ b/src/webhooks/github/events.rs
@@ -144,5 +144,5 @@ pub struct PrRef {
 
 #[derive(Debug, Deserialize)]
 pub struct PullRequestLinks {
-    html_url: Url,
+    pub html_url: Url,
 }

--- a/src/webhooks/github/events/commit_comment.rs
+++ b/src/webhooks/github/events/commit_comment.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+use crate::webhooks::github::events::{Comment, GitHubUser, Repository};
+
+#[derive(Debug, Deserialize)]
+pub struct CommitCommentEvent {
+    pub sender: GitHubUser,
+    pub repository: Repository,
+    pub comment: Comment,
+}

--- a/src/webhooks/github/events/fork.rs
+++ b/src/webhooks/github/events/fork.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+use crate::webhooks::github::events::{GitHubUser, Repository};
+
+#[derive(Debug, Deserialize)]
+pub struct ForkEvent {
+    pub forkee: Repository,
+    pub repository: Repository,
+    pub sender: GitHubUser,
+}

--- a/src/webhooks/github/events/membership.rs
+++ b/src/webhooks/github/events/membership.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+use crate::webhooks::github::events::{GitHubUser, Team};
+
+#[derive(Debug, Deserialize)]
+pub struct MembershipEvent {
+    pub action: String,
+    pub member: GitHubUser,
+    pub team: Team,
+    pub sender: GitHubUser,
+}

--- a/src/webhooks/github/events/organization.rs
+++ b/src/webhooks/github/events/organization.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+
+use crate::webhooks::github::events::GitHubUser;
+
+#[derive(Debug, Deserialize)]
+pub struct OrganizationEvent {
+    pub action: String,
+    pub sender: GitHubUser,
+
+    // When 'invitation', 'user' should be set
+    pub invitation: Option<OrganizationInvitation>,
+    pub user: Option<GitHubUser>,
+
+    // Otherwise, 'user' is accessed through 'membership'
+    pub membership: Option<OrganizationMembership>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OrganizationInvitation {
+    pub role: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OrganizationMembership {
+    pub role: String,
+    pub user: GitHubUser,
+}

--- a/src/webhooks/github/events/ping.rs
+++ b/src/webhooks/github/events/ping.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+
+use crate::webhooks::github::events::{GitHubUser, Repository};
+
+#[derive(Debug, Deserialize)]
+pub struct PingEvent {
+    pub zen: String,
+    pub repository: Option<Repository>,
+    pub sender: GitHubUser,
+}

--- a/src/webhooks/github/events/repository.rs
+++ b/src/webhooks/github/events/repository.rs
@@ -1,0 +1,26 @@
+use serde::Deserialize;
+
+use crate::webhooks::github::events::{GitHubUser, Repository};
+
+#[derive(Debug, Deserialize)]
+pub struct RepositoryEvent {
+    pub action: String,
+    pub repository: Repository,
+    pub sender: GitHubUser,
+    pub changes: Option<RepositoryChanges>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepositoryChanges {
+    pub repository: RepositoryChangesName,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepositoryChangesName {
+    pub name: RepositoryChangesNameFrom,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepositoryChangesNameFrom {
+    pub from: String,
+}

--- a/src/webhooks/github/events/types.rs
+++ b/src/webhooks/github/events/types.rs
@@ -12,6 +12,7 @@ use crate::webhooks::github::{GitHubEvent, SignedGitHubPayload, X_GITHUB_EVENT};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GitHubEventType {
+    Ping,
     Create,
     Issues,
     IssueComment,
@@ -19,6 +20,7 @@ pub enum GitHubEventType {
     PullRequestReview,
     PullRequestReviewComment,
     Push,
+    Repository,
     Unknown,
 }
 
@@ -28,6 +30,7 @@ impl GitHubEventType {
         payload: &SignedGitHubPayload,
     ) -> anyhow::Result<GitHubEvent> {
         Ok(match self {
+            Self::Ping => GitHubEvent::Ping(serde_json::from_str(&payload.0)?),
             Self::Create => GitHubEvent::Create(serde_json::from_str(&payload.0)?),
             Self::IssueComment => GitHubEvent::IssueComment(serde_json::from_str(&payload.0)?),
             Self::Issues => GitHubEvent::Issues(serde_json::from_str(&payload.0)?),
@@ -39,6 +42,7 @@ impl GitHubEventType {
                 GitHubEvent::PullRequestReviewComment(serde_json::from_str(&payload.0)?)
             }
             Self::Push => GitHubEvent::Push(serde_json::from_str(&payload.0)?),
+            Self::Repository => GitHubEvent::Repository(serde_json::from_str(&payload.0)?),
             Self::Unknown => bail!("unknown event type"),
         })
     }

--- a/src/webhooks/github/events/types.rs
+++ b/src/webhooks/github/events/types.rs
@@ -13,6 +13,7 @@ use crate::webhooks::github::{GitHubEvent, SignedGitHubPayload, X_GITHUB_EVENT};
 #[serde(rename_all = "snake_case")]
 pub enum GitHubEventType {
     Ping,
+    CommitComment,
     Create,
     Fork,
     Issues,
@@ -33,6 +34,7 @@ impl GitHubEventType {
     ) -> anyhow::Result<GitHubEvent> {
         Ok(match self {
             Self::Ping => GitHubEvent::Ping(serde_json::from_str(&payload.0)?),
+            Self::CommitComment => GitHubEvent::CommitComment(serde_json::from_str(&payload.0)?),
             Self::Create => GitHubEvent::Create(serde_json::from_str(&payload.0)?),
             Self::Fork => GitHubEvent::Fork(serde_json::from_str(&payload.0)?),
             Self::IssueComment => GitHubEvent::IssueComment(serde_json::from_str(&payload.0)?),

--- a/src/webhooks/github/events/types.rs
+++ b/src/webhooks/github/events/types.rs
@@ -12,13 +12,14 @@ use crate::webhooks::github::{GitHubEvent, SignedGitHubPayload, X_GITHUB_EVENT};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GitHubEventType {
-    Ping,
     CommitComment,
     Create,
     Fork,
-    Issues,
     IssueComment,
+    Issues,
+    Membership,
     Organization,
+    Ping,
     PullRequest,
     PullRequestReview,
     PullRequestReviewComment,
@@ -33,13 +34,14 @@ impl GitHubEventType {
         payload: &SignedGitHubPayload,
     ) -> anyhow::Result<GitHubEvent> {
         Ok(match self {
-            Self::Ping => GitHubEvent::Ping(serde_json::from_str(&payload.0)?),
             Self::CommitComment => GitHubEvent::CommitComment(serde_json::from_str(&payload.0)?),
             Self::Create => GitHubEvent::Create(serde_json::from_str(&payload.0)?),
             Self::Fork => GitHubEvent::Fork(serde_json::from_str(&payload.0)?),
             Self::IssueComment => GitHubEvent::IssueComment(serde_json::from_str(&payload.0)?),
             Self::Issues => GitHubEvent::Issues(serde_json::from_str(&payload.0)?),
+            Self::Membership => GitHubEvent::Membership(serde_json::from_str(&payload.0)?),
             Self::Organization => GitHubEvent::Organization(serde_json::from_str(&payload.0)?),
+            Self::Ping => GitHubEvent::Ping(serde_json::from_str(&payload.0)?),
             Self::PullRequest => GitHubEvent::PullRequest(serde_json::from_str(&payload.0)?),
             Self::PullRequestReview => {
                 GitHubEvent::PullRequestReview(serde_json::from_str(&payload.0)?)

--- a/src/webhooks/github/events/types.rs
+++ b/src/webhooks/github/events/types.rs
@@ -16,6 +16,7 @@ pub enum GitHubEventType {
     Create,
     Issues,
     IssueComment,
+    Organization,
     PullRequest,
     PullRequestReview,
     PullRequestReviewComment,
@@ -34,6 +35,7 @@ impl GitHubEventType {
             Self::Create => GitHubEvent::Create(serde_json::from_str(&payload.0)?),
             Self::IssueComment => GitHubEvent::IssueComment(serde_json::from_str(&payload.0)?),
             Self::Issues => GitHubEvent::Issues(serde_json::from_str(&payload.0)?),
+            Self::Organization => GitHubEvent::Organization(serde_json::from_str(&payload.0)?),
             Self::PullRequest => GitHubEvent::PullRequest(serde_json::from_str(&payload.0)?),
             Self::PullRequestReview => {
                 GitHubEvent::PullRequestReview(serde_json::from_str(&payload.0)?)

--- a/src/webhooks/github/events/types.rs
+++ b/src/webhooks/github/events/types.rs
@@ -14,6 +14,7 @@ use crate::webhooks::github::{GitHubEvent, SignedGitHubPayload, X_GITHUB_EVENT};
 pub enum GitHubEventType {
     Ping,
     Create,
+    Fork,
     Issues,
     IssueComment,
     Organization,
@@ -33,6 +34,7 @@ impl GitHubEventType {
         Ok(match self {
             Self::Ping => GitHubEvent::Ping(serde_json::from_str(&payload.0)?),
             Self::Create => GitHubEvent::Create(serde_json::from_str(&payload.0)?),
+            Self::Fork => GitHubEvent::Fork(serde_json::from_str(&payload.0)?),
             Self::IssueComment => GitHubEvent::IssueComment(serde_json::from_str(&payload.0)?),
             Self::Issues => GitHubEvent::Issues(serde_json::from_str(&payload.0)?),
             Self::Organization => GitHubEvent::Organization(serde_json::from_str(&payload.0)?),

--- a/src/webhooks/prolosite.rs
+++ b/src/webhooks/prolosite.rs
@@ -122,6 +122,7 @@ pub(crate) struct Request {
 #[derive(Debug, Deserialize)]
 pub(crate) struct Exception {
     pub(crate) value: String,
+    #[allow(dead_code)]
     pub(crate) trace: Vec<String>,
 }
 


### PR DESCRIPTION
Add support for more GitHub events. It is planned to support all missing events described in #1.

Also, note that I added support for "Ping" event. Kinda useless for general use but I believe it could be helpful for newcomers to know they've successfully setup prololo/matrix/webhooks instead of having an error.