### PR TITLE
Add generic endpoint handling

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -29,6 +29,9 @@ use handlers::autojoin_authorized_rooms;
 mod prolosite;
 use prolosite::handle_prolosite_event;
 
+mod generic;
+use generic::handle_generic_event;
+
 mod message_builder;
 use message_builder::MessageBuilder;
 
@@ -121,6 +124,7 @@ impl Prololo {
         let response = match event {
             Event::GitHub(event) => handle_github_event(event)?,
             Event::ProloSite(event) => handle_prolosite_event(event)?,
+            Event::Generic(event) => handle_generic_event(event)?,
         };
 
         let Response { message, repo } = match response {

--- a/src/bot/generic.rs
+++ b/src/bot/generic.rs
@@ -1,0 +1,64 @@
+use std::fmt::Write;
+
+use tracing::trace;
+
+use crate::{
+    bot::{message_builder::MessageBuilder, Response},
+    webhooks::GenericEvent,
+};
+
+pub(crate) fn handle_generic_event(event: GenericEvent) -> anyhow::Result<Option<Response>> {
+    trace!("handling generic event");
+    let GenericEvent(event) = event;
+
+    let mut message = MessageBuilder::new();
+
+    if let Some(tag) = event.tag {
+        message.tag(&tag, None);
+        write!(message, " ").unwrap();
+    }
+
+    write!(message, "{}", event.message).unwrap();
+
+    if let Some(url) = event.url {
+        write!(message, " ({})", url).unwrap();
+    }
+
+    Ok(Some(Response {
+        message,
+        repo: None,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use crate::webhooks::generic::GenericPayload;
+
+    use super::*;
+
+    #[test]
+    fn test_handle_generic_event() {
+        let event = GenericEvent(GenericPayload {
+            message: "Hello World!".to_string(),
+            tag: Some("generic".to_string()),
+            url: Some(Url::parse("https://prologin.org/").unwrap()),
+        });
+
+        let response = handle_generic_event(event)
+            .expect("should have a response")
+            .unwrap();
+        let message = response.message;
+
+        assert_eq!(
+            message.plain,
+            "[generic] Hello World! (https://prologin.org/)"
+        );
+
+        assert_eq!(
+            message.html,
+            "<b>[generic]</b> Hello World! (https://prologin.org/)"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct ProloloConfig {
     pub matrix_rooms: HashMap<String, RoomConfig>,
     /// Mappings from all repos matching a certain regex, to a specific Matrix room
     pub destinations: Vec<Destination>,
+    /// Generic endpoints
+    pub generic_endpoints: Option<HashMap<String, GenericEndpoint>>,
     /// Secret used to verify HMAC signature of GitHub webhooks
     pub github_secret: String,
     /// Secret token used in Authorization header for Prologin site hooks
@@ -42,6 +44,14 @@ pub struct Destination {
     /// The regex used to match some repos to this destination
     #[serde(with = "serde_regex")]
     pub regex: Regex,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GenericEndpoint {
+    /// The room name as used in [`ProloloConfig::matrix_rooms`]
+    pub room: String,
+    /// The secret used to authenticate requests to this endpoint
+    pub secret: String,
 }
 
 impl ProloloConfig {

--- a/src/webhooks.rs
+++ b/src/webhooks.rs
@@ -1,10 +1,25 @@
+use anyhow::anyhow;
+use rocket::{
+    http::Status,
+    request::{FromRequest, Outcome},
+    State,
+};
 use tokio::sync::mpsc::UnboundedSender;
+
+use tracing::{debug, trace};
 
 pub mod github;
 pub use github::{github_webhook, GitHubEvent};
 
 pub mod prolosite;
 pub(crate) use prolosite::ProloSiteEvent;
+
+pub mod generic;
+pub(crate) use generic::GenericEvent;
+
+use crate::config::ProloloConfig;
+
+pub struct Config(pub ProloloConfig);
 
 pub struct EventSender(pub UnboundedSender<Event>);
 
@@ -13,4 +28,60 @@ pub struct EventSender(pub UnboundedSender<Event>);
 pub enum Event {
     GitHub(GitHubEvent),
     ProloSite(ProloSiteEvent),
+    Generic(GenericEvent),
+}
+
+const AUTHORIZATION: &str = "Authorization";
+
+pub(crate) struct AuthorizationHeader<'r>(&'r str);
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AuthorizationHeader<'r> {
+    type Error = anyhow::Error;
+
+    async fn from_request(request: &'r rocket::Request<'_>) -> Outcome<Self, Self::Error> {
+        let authorization = request.headers().get(AUTHORIZATION).collect::<Vec<_>>();
+        if authorization.len() != 1 {
+            trace!("couldn't locate {} header", AUTHORIZATION);
+            return Outcome::Failure((
+                Status::BadRequest,
+                anyhow!("request needs an authorization header"),
+            ));
+        }
+        let authorization = authorization[0];
+        debug!("{:?}", request);
+        let prololo_config = &request.guard::<&State<Config>>().await.unwrap().0;
+
+        let endpoint_segments: Vec<&str> = request.uri().path().segments().skip(2).collect();
+        let auth_secret = match endpoint_segments[0] {
+            "prolosite" => Some(prololo_config.prolosite_secret.as_str()),
+            "generic" => match &prololo_config.generic_endpoints {
+                Some(generic_endpoints) => {
+                    let secret = match generic_endpoints.get(endpoint_segments[1]) {
+                        Some(endpoint) => endpoint.secret.as_str(),
+                        None => {
+                            return Outcome::Failure((
+                                Status::NotFound,
+                                anyhow!("no endpoint named '{}'", endpoint_segments[1]),
+                            ))
+                        }
+                    };
+
+                    Some(secret)
+                }
+                None => {
+                    return Outcome::Failure((Status::NotFound, anyhow!("no endpoint configured")));
+                }
+            },
+            _ => None,
+        };
+
+        if Some(authorization) != auth_secret {
+            trace!("secret validation failed, stopping here...");
+            return Outcome::Failure((Status::BadRequest, anyhow!("secret doesn't match")));
+        }
+
+        trace!("validated request");
+        Outcome::Success(AuthorizationHeader(authorization))
+    }
 }

--- a/src/webhooks/generic.rs
+++ b/src/webhooks/generic.rs
@@ -1,0 +1,36 @@
+use rocket::{serde::json::Json, State};
+use serde::Deserialize;
+use tracing::{debug, trace};
+use url::Url;
+
+use crate::webhooks::{AuthorizationHeader, Event, EventSender};
+
+#[derive(Debug)]
+pub struct GenericEvent(pub GenericPayload);
+
+#[rocket::post(
+    "/api/webhooks/generic/<endpoint>",
+    format = "json",
+    data = "<payload>"
+)]
+pub(crate) fn generic(
+    endpoint: String,
+    _token: AuthorizationHeader,
+    payload: Json<GenericPayload>,
+    sender: &State<EventSender>,
+) {
+    debug!("received request on endpoint '{}'", endpoint);
+    trace!("payload: {:?}", payload.0);
+
+    sender
+        .0
+        .send(Event::Generic(GenericEvent(payload.into_inner())))
+        .expect("mspc channel was closed / dropped");
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GenericPayload {
+    pub(crate) tag: Option<String>,
+    pub(crate) message: String,
+    pub(crate) url: Option<Url>,
+}

--- a/src/webhooks/github.rs
+++ b/src/webhooks/github.rs
@@ -11,8 +11,6 @@ use crate::webhooks::{Event, EventSender};
 
 pub const X_GITHUB_EVENT: &str = "X-GitHub-Event";
 
-pub struct GitHubSecret(pub String);
-
 #[rocket::post("/api/webhooks/github", data = "<payload>")]
 pub fn github_webhook(
     event: GitHubEventType,

--- a/src/webhooks/github/signing.rs
+++ b/src/webhooks/github/signing.rs
@@ -8,7 +8,7 @@ use rocket::{
 };
 use tracing::trace;
 
-use crate::webhooks::github::GitHubSecret;
+use crate::webhooks::Config;
 
 const X_GITHUB_SIGNATURE: &str = "X-Hub-Signature-256";
 
@@ -90,9 +90,14 @@ impl<'r> FromData<'r> for SignedGitHubPayload {
         };
 
         let signature = signatures[0];
-        let secret = request.guard::<&State<GitHubSecret>>().await.unwrap();
+        let secret = &request
+            .guard::<&State<Config>>()
+            .await
+            .unwrap()
+            .0
+            .github_secret;
 
-        if !validate_signature(&secret.0, signature, &content) {
+        if !validate_signature(secret, signature, &content) {
             trace!("signature validation failed, stopping here...");
             return Outcome::Failure((Status::BadRequest, anyhow!("couldn't verify signature")));
         }

--- a/src/webhooks/prolosite.rs
+++ b/src/webhooks/prolosite.rs
@@ -1,19 +1,11 @@
 use std::path::PathBuf;
 
-use anyhow::anyhow;
-use rocket::{
-    http::Status,
-    request::{FromRequest, Outcome},
-    serde::json::Json,
-    State,
-};
+use rocket::{serde::json::Json, State};
 use serde::Deserialize;
 use tracing::{info, trace};
 use url::Url;
 
-use crate::webhooks::{Event, EventSender};
-
-const AUTHORIZATION: &str = "Authorization";
+use crate::webhooks::{AuthorizationHeader, Event, EventSender};
 
 #[derive(Debug)]
 pub enum ProloSiteEvent {
@@ -21,36 +13,6 @@ pub enum ProloSiteEvent {
     Forum(ForumPayload),
     NewSchool(NewSchoolPayload),
     Impersonate(ImpersonatePayload),
-}
-
-pub struct ProlositeSecret(pub String);
-
-pub(crate) struct AuthorizationHeader<'r>(&'r str);
-
-#[rocket::async_trait]
-impl<'r> FromRequest<'r> for AuthorizationHeader<'r> {
-    type Error = anyhow::Error;
-
-    async fn from_request(request: &'r rocket::Request<'_>) -> Outcome<Self, Self::Error> {
-        let authorization = request.headers().get(AUTHORIZATION).collect::<Vec<_>>();
-        if authorization.len() != 1 {
-            trace!("couldn't locate {} header", AUTHORIZATION);
-            return Outcome::Failure((
-                Status::BadRequest,
-                anyhow!("request needs an authorization header"),
-            ));
-        }
-        let authorization = authorization[0];
-        let auth_secret = &request.guard::<&State<ProlositeSecret>>().await.unwrap().0;
-
-        if authorization != auth_secret {
-            trace!("secret validation failed, stopping here...");
-            return Outcome::Failure((Status::BadRequest, anyhow!("secret doesn't match")));
-        }
-
-        trace!("validated Prolosite request");
-        Outcome::Success(AuthorizationHeader(authorization))
-    }
 }
 
 #[rocket::post("/api/webhooks/prolosite/django", format = "json", data = "<payload>")]


### PR DESCRIPTION
Closes #28.

The config file now looks like this:
```yaml
---
matrix_homeserver: https://matrix.prologin.org

matrix_username: prololo
matrix_password: "alarsyoleplusbeau"

matrix_state_dir: /var/prololo

matrix_rooms:
  super-room:
    id: "!xBbVTMAykIXvXSXOOe:matrix.prologin.org"

destinations:
  - room: "super-room"
    regex: ".*"

generic_endpoints:
  new-endpoint:
    room: "super-room"
    secret: "what_a_really_strong_secret_for_my_endpoint"

github_secret: "I_have_no_secret_for_you"

prolosite_secret: "prololo_is_my_only_love"
```

Note that the endpoint full URL will be `/api/webhooks/generic/new-endpoint`, also the config `generic_endpoints` is obviously optional.

The payload accepted by this endpoint is:

```json
{
  "tag": "generic",
  "message": "Hello World!",
  "url": "https://prologin.org"
}
 ```
with `message` being the only mandatory field.

Feedbacks are welcome :wink: 